### PR TITLE
FIXED: Typo

### DIFF
--- a/head/metadata.tex
+++ b/head/metadata.tex
@@ -9,7 +9,7 @@
 \newcommand{\plz}{0000}
 \newcommand{\modul}{WIAGRU}
 \newcommand{\email}{max.mustermann@stud.fhgr.ch}
-\newcommand{\refe}{Prof, Dr. Eva Mustermann}
+\newcommand{\refe}{Prof. Dr. Eva Mustermann}
 \newcommand{\coRefe}{Julian Junke}
 \newcommand{\abgabedatum}{TT.MM.YYYY}
 \newcommand{\abgabedatumRFC}{YYYY-MM-TT}


### PR DESCRIPTION
Schreiben sich mit Punkt nicht Komma.
Quelle: https://www.fhgr.ch/personen/person/roelke/