### PR TITLE
CHANGED: Titelblatt to match Leitfaden

### DIFF
--- a/content/01_vorspann/01.1_titelblatt.tex
+++ b/content/01_vorspann/01.1_titelblatt.tex
@@ -16,19 +16,11 @@
     Matrikelnr.: \matrikelnummer\\
     Adresse: \adresse, \plz~\ort\\
     E-Mail: \email\\
-    \end{flushleft}
-    
-    \vspace{0mm}
-    
-    \begin{flushleft}
+    ~\\
     Modul: \modul\\
     Referent/in: \refe\\
     Koreferent/in: \coRefe\\
-    \end{flushleft}
-    
-    \vspace{0mm}
-    
-    \begin{flushleft}
+    ~\\
     Abgabedatum: \abgabedatum
     \end{flushleft}
     

--- a/content/01_vorspann/01.1_titelblatt.tex
+++ b/content/01_vorspann/01.1_titelblatt.tex
@@ -1,29 +1,37 @@
 \begin{titlepage}
     
     \begin{center}
-        Fachhochschule Graubünden, [Institutsname]
-        \vfill
+        Fachhochschule Graubünden, [Institutsname] \\
+        \vspace{30mm}
         \huge\textbf{\haupttitel}\\
+        \hfill \break
         \large{(\untertitel)}
     \end{center}
     
     \vfill
     
-    \begin{tabbing}
+    \begin{flushleft}
     Name: \autorenschaft\\
     Studiengang: \studiengang\\
     Matrikelnr.: \matrikelnummer\\
     Adresse: \adresse, \plz~\ort\\
     E-Mail: \email\\
-    \\
+    \end{flushleft}
+    
+    \vspace{0mm}
+    
+    \begin{flushleft}
     Modul: \modul\\
     Referent/in: \refe\\
     Koreferent/in: \coRefe\\
-    \\
+    \end{flushleft}
+    
+    \vspace{0mm}
+    
+    \begin{flushleft}
     Abgabedatum: \abgabedatum
-    \end{tabbing}
+    \end{flushleft}
     
-    \vfill
+    \vspace{20mm}
     
-
 \end{titlepage}


### PR DESCRIPTION
Ich finde, so sieht es mehr nach dem Beispiel im Kapitel 10 Anhang A des Leitfadens zum wissenschaftlichen Arbeiten aus.

Ich bin mir nicht sicher, ob die Verwendung von `vspace` und `flushleft` in Ordnung ist.