### PR TITLE
FIXED: Page Numberings and TOC

### DIFF
--- a/config/main.tex
+++ b/config/main.tex
@@ -5,10 +5,10 @@
 \input{config/preamble}
 \begin{document}
 
-    \renewcommand*\listfigurename{\customTitle{Abbildungsverzeichnis}}
-    \renewcommand*\listtablename{\customTitle{Tabellenverzeichnis}}
+    \renewcommand*\listfigurename{\customTitle{}}
+    \renewcommand*\listtablename{\customTitle{}}
     \renewcommand*\contentsname{\customTitle{Inhaltsverzeichnis}}
-    \renewcommand*{\acronymname}{\customTitle{Abkürzungsverzeichnis}}
+    \renewcommand*{\acronymname}{\customTitle{}}
     
     % Start Vorspann
     

--- a/config/main.tex
+++ b/config/main.tex
@@ -16,26 +16,38 @@
     \input{content/01_vorspann/01.1_titelblatt}
     \include{content/01_vorspann/01.2_abstract}
     \include{content/01_vorspann/01.3_vorwort}
-    \setcounter{page}{2}
+
     \tableofcontents % Inhaltsverzeichnis
+    
     \begingroup
         \renewcommand*{\addvspace}[1]{}
+        
         \newpage
+        \pagenumbering{arabic} 
+        \phantomsection
+        \addcontentsline{toc}{chapter}{\protect
+        \numberline{}Abbildungsverzeichnis}
     	\listoffigures % Abbildungsverzeichnis
+     
     	\newpage
+        \phantomsection
+        \addcontentsline{toc}{chapter}{\protect
+        \numberline{}Tabellenverzeichnis}
     	\listoftables % Tabellenverzeichnis
     \endgroup
 
     % Settings table of acronyms
     \setacronymstyle{long-short}
     \setglossarystyle{listdotted}
+    \phantomsection
+    \addcontentsline{toc}{chapter}{\protect
+    \numberline{}Abkürzungsverzeichnis}
     \printnoidxglossary[type=\acronymtype]
     \include{content/01_vorspann/01.4_abkuerzungsverzeichnis}
     
     % Ende Vorspann
     
     % Start Textteil
-    \pagenumbering{arabic} 
     \include{content/02_textteil/einleitung}
     \include{content/02_textteil/kapitel1}
     % Ende Textteil

--- a/config/main.tex
+++ b/config/main.tex
@@ -24,24 +24,18 @@
         
         \newpage
         \pagenumbering{arabic} 
-        \phantomsection
-        \addcontentsline{toc}{chapter}{\protect
-        \numberline{}Abbildungsverzeichnis}
+        \chapterNoNr{Abbildungsverzeichnis}
     	\listoffigures % Abbildungsverzeichnis
      
     	\newpage
-        \phantomsection
-        \addcontentsline{toc}{chapter}{\protect
-        \numberline{}Tabellenverzeichnis}
+        \chapterNoNr{Tabellenverzeichnis}
     	\listoftables % Tabellenverzeichnis
     \endgroup
 
     % Settings table of acronyms
     \setacronymstyle{long-short}
     \setglossarystyle{listdotted}
-    \phantomsection
-    \addcontentsline{toc}{chapter}{\protect
-    \numberline{}Abkürzungsverzeichnis}
+    \chapterNoNr{Abkürzungsverzeichnis}
     \printnoidxglossary[type=\acronymtype]
     \include{content/01_vorspann/01.4_abkuerzungsverzeichnis}
     

--- a/config/main.tex
+++ b/config/main.tex
@@ -5,10 +5,10 @@
 \input{config/preamble}
 \begin{document}
 
-    \renewcommand*\listfigurename{\customTitle{}}
-    \renewcommand*\listtablename{\customTitle{}}
+    \renewcommand*\listfigurename{\customTitle{Abbildungsverzeichnis}}
+    \renewcommand*\listtablename{\customTitle{Tabellenverzeichnis}}
     \renewcommand*\contentsname{\customTitle{Inhaltsverzeichnis}}
-    \renewcommand*{\acronymname}{\customTitle{}}
+    \renewcommand*{\acronymname}{\customTitle{Abkürzungsverzeichnis}}
     
     % Start Vorspann
     
@@ -22,20 +22,27 @@
     \begingroup
         \renewcommand*{\addvspace}[1]{}
         
-        \newpage
-        \pagenumbering{arabic} 
-        \chapterNoNr{Abbildungsverzeichnis}
-    	\listoffigures % Abbildungsverzeichnis
+        \pagenumbering{arabic}
+        
+        % Abbildungsverzeichnis
+        \cleardoublepage
+        \phantomsection
+        \addcontentsline{toc}{chapter}{Abbildungsverzeichnis}
+    	\listoffigures
      
-    	\newpage
-        \chapterNoNr{Tabellenverzeichnis}
-    	\listoftables % Tabellenverzeichnis
+        % Tabellenverzeichnis
+        \cleardoublepage
+        \phantomsection
+        \addcontentsline{toc}{chapter}{Tabellenverzeichnis}
+    	\listoftables
     \endgroup
 
     % Settings table of acronyms
+    \cleardoublepage
+    \phantomsection
+    \addcontentsline{toc}{chapter}{Abkürzungsverzeichnis}
     \setacronymstyle{long-short}
     \setglossarystyle{listdotted}
-    \chapterNoNr{Abkürzungsverzeichnis}
     \printnoidxglossary[type=\acronymtype]
     \include{content/01_vorspann/01.4_abkuerzungsverzeichnis}
     


### PR DESCRIPTION
# Wrong Page numberings:
![image](https://github.com/giodi/Vorlage-FHGR/assets/34353267/103868ff-67cb-4167-b0e1-8efe48f89b83)
Abbildungsverzeichnis, Tabelenverzeichnis und Abkürzungsverzeichnis waren römisch

# Missing entries in table of contents
Gemäss [Scribbr-Beispiel](https://www.scribbr.ch/aufbau-und-gliederung-ch/inhaltsverzeichnis-bachelorarbeit/) sind Abbildungsverzeichnis, Tabellenverzeichnis und Abkürzungsverzeichnis im Inhaltsverzeichnis